### PR TITLE
Patch v4.0.1

### DIFF
--- a/AwqatSalaat.Common/ViewModels/PrayerTimeViewModel.cs
+++ b/AwqatSalaat.Common/ViewModels/PrayerTimeViewModel.cs
@@ -72,7 +72,11 @@ namespace AwqatSalaat.ViewModels
 
         public void InvalidateConfig()
         {
-            Time = apiTime.AddMinutes(config.Adjustment);
+            if (apiTime != DateTime.MinValue)
+            {
+                Time = apiTime.AddMinutes(config.Adjustment);
+            }
+
             Distance = config.EffectiveReminderOffset();
             DistanceElapsed = config.EffectiveElapsedTime();
             IsVisible = config.IsVisible;

--- a/AwqatSalaat.Common/ViewModels/WidgetSettingsViewModel.cs
+++ b/AwqatSalaat.Common/ViewModels/WidgetSettingsViewModel.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.Configuration;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Settings = AwqatSalaat.Properties.Settings;
 
@@ -98,22 +99,22 @@ namespace AwqatSalaat.ViewModels
             };
         }
 
-        public async Task<Release> CheckForNewVersion(Version currentVersion)
+        public async Task<Release> CheckForNewVersion(Version currentVersion, CancellationToken cancellationToken)
         {
             try
             {
                 IsCheckingNewVersion = true;
 
-                var latest = await GitHubClient.GetLatestRelease();
+                var latest = await GitHubClient.GetLatestRelease(cancellationToken);
 
-                if (latest is null)
+                if (cancellationToken.IsCancellationRequested || latest is null)
                 {
                     return null;
                 }
 
                 if (latest.IsDraft || latest.IsPreRelease)
                 {
-                    var allReleases = await GitHubClient.GetReleases();
+                    var allReleases = await GitHubClient.GetReleases(cancellationToken);
 
                     if (allReleases?.Length > 1)
                     {

--- a/AwqatSalaat.WinUI/TaskBarWidget.cs
+++ b/AwqatSalaat.WinUI/TaskBarWidget.cs
@@ -529,8 +529,9 @@ namespace AwqatSalaat.WinUI
             {
                 StringBuilder builder = new StringBuilder(256);
                 User32.GetClassName(hWnd, builder, builder.MaxCapacity);
+                string className = builder.ToString();
 
-                if (!IsSystemWindow(builder.ToString()))
+                if (!IsSystemWindow(className) && className != "#32770")
                 {
                     GCHandle gcChildhandlesList = GCHandle.FromIntPtr(lParam);
                     List<IntPtr> childHandles = gcChildhandlesList.Target as List<IntPtr>;

--- a/AwqatSalaat.WinUI/TaskBarWidget.cs
+++ b/AwqatSalaat.WinUI/TaskBarWidget.cs
@@ -18,7 +18,6 @@ namespace AwqatSalaat.WinUI
 {
     internal class TaskBarWidget : IDisposable
     {
-        private const string WidgetClassName = "AwqatSalaatWidgetWinRT";
         private const string TaskBarClassName = "Shell_TrayWnd";
         private const string ReBarWindow32ClassName = "ReBarWindow32";
         private const string NotificationAreaClassName = "TrayNotifyWnd";
@@ -33,6 +32,7 @@ namespace AwqatSalaat.WinUI
         private readonly IntPtr hwndShell;
         private readonly IntPtr hwndTrayNotify;
         private readonly IntPtr hwndReBar;
+        private readonly string WidgetClassName = "AwqatSalaatWidgetWinRT";
 
         private readonly TaskbarStructureWatcher taskbarWatcher;
 
@@ -69,6 +69,14 @@ namespace AwqatSalaat.WinUI
             taskbarWatcher = new TaskbarStructureWatcher(hwndShell, hwndReBar);
             taskbarWatcher.TaskbarChangedNotificationStarted += TaskbarWatcher_TaskbarChangedNotificationStarted;
             taskbarWatcher.TaskbarChangedNotificationCompleted += TaskbarWatcher_TaskbarChangedNotificationCompleted;
+
+            // Workaround for issues caused by Start11 v2
+            var hwndStart11Taskbar = User32.FindWindowEx(hwndShell, IntPtr.Zero, "#32770", "SDTaskbar");
+
+            if (hwndStart11Taskbar != IntPtr.Zero)
+            {
+                WidgetClassName = "#32770";
+            }
         }
 
         public void Initialize()

--- a/AwqatSalaat.WinUI/Views/CalendarPage.xaml
+++ b/AwqatSalaat.WinUI/Views/CalendarPage.xaml
@@ -15,6 +15,7 @@
     Background="Transparent"
     Margin="24,0,24,16"
     IsEnabled="{x:Bind ViewModel.IsBusy, Converter={StaticResource BooleanInvertedConverter}}"
+    NavigationCacheMode="Enabled"
     x:DefaultBindMode="OneWay">
     <Page.Resources>
         <Style x:Key="StandardRecordContainerStyle" TargetType="ListBoxItem">

--- a/AwqatSalaat.WinUI/Views/LearnPage.xaml
+++ b/AwqatSalaat.WinUI/Views/LearnPage.xaml
@@ -6,7 +6,8 @@
     xmlns:local="using:AwqatSalaat.WinUI.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    NavigationCacheMode="Enabled">
     <Page.Resources>
         <FontFamily x:Key="UthmanicHafs">ms-appx:///Fonts/UthmanicHafs_v2-1.ttf#KFGQPC HAFS Uthmanic Script</FontFamily>
         <FontFamily x:Key="UthmanTahaNaskh">ms-appx:///Fonts/UthmanTN_v2-0.ttf#KFGQPC Uthman Taha Naskh</FontFamily>

--- a/AwqatSalaat.WinUI/Views/LearnPage.xaml.cs
+++ b/AwqatSalaat.WinUI/Views/LearnPage.xaml.cs
@@ -49,13 +49,6 @@ namespace AwqatSalaat.WinUI.Views
             LoadRtf();
         }
 
-        protected override void OnNavigatedFrom(NavigationEventArgs e)
-        {
-            base.OnNavigatedFrom(e);
-
-            Dispose();
-        }
-
         private void LoadRtf()
         {
             Log.Information("Loading rtf file");

--- a/AwqatSalaat/Media/AudioPlayer.cs
+++ b/AwqatSalaat/Media/AudioPlayer.cs
@@ -7,7 +7,7 @@ namespace AwqatSalaat.Media
 {
     internal static class AudioPlayer
     {
-        private static readonly MediaPlayer s_mediaPlayer = new MediaPlayer() { Volume = 1 };
+        private static readonly MediaPlayer s_mediaPlayer = new MediaPlayer();
         private static AudioPlayerSession s_currentSession;
 
         public static AudioPlayerSession CurrentSession => s_currentSession;
@@ -28,6 +28,7 @@ namespace AwqatSalaat.Media
                 s_mediaPlayer.MediaFailed += MediaPlayer_MediaFailed;
                 s_mediaPlayer.Open(new Uri(session.File));
                 s_mediaPlayer.Position = TimeSpan.Zero;
+                s_mediaPlayer.Volume = 1;
                 s_mediaPlayer.Play();
                 s_currentSession = session;
                 s_currentSession.Ended += Session_Ended;


### PR DESCRIPTION
### Bug fixes

- Cancel updates checking when closing Settings panel.
- Fix crashing due to negative prayer time adjustment.
- Fix volume decrease after playing an audio the first time. (Deskband only)
- Enable chaching the content of the pages in **More info** window. (WinUI only)
- Implement workarounds to the issues caused by Start11 v2. (WinUI only)

