### PR TITLE
Patch v4.2.2

### DIFF
--- a/AwqatSalaat.WinUI.MSIX/Package.appxmanifest
+++ b/AwqatSalaat.WinUI.MSIX/Package.appxmanifest
@@ -12,7 +12,7 @@
     <Identity
         Name="Khiro.AwqatSalaatWinUI"
         Publisher="CN=C005A407-3926-439C-B560-3187F3293A86"
-        Version="4.2.1.0" />
+        Version="4.2.2.0" />
 
     <Properties>
         <DisplayName>ms-resource:AppDisplayName</DisplayName>

--- a/AwqatSalaat.WinUI/Views/WidgetSummary.xaml.cs
+++ b/AwqatSalaat.WinUI/Views/WidgetSummary.xaml.cs
@@ -156,7 +156,7 @@ namespace AwqatSalaat.WinUI.Views
             UpdateDisplayMode();
             UpdateDisplayMenu();
 #if PACKAGED
-            InvalidateLockScreenTimer();
+            DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, UpdateLockScreen);
 #endif
         }
 

--- a/CHANGELOG.ar.md
+++ b/CHANGELOG.ar.md
@@ -1,7 +1,11 @@
-﻿### نسخة v4.2.1
+﻿### نسخة v4.2.2
+
+- تطبيق حل لخلل re-rentrancy الناتج من TileNotification في حدث Loaded الخاص بزر الأداة. (نسخة WinUI من خلال متجر مايكروسوفت فقط)
+
+### نسخة v4.2.1
 
 - تجنب مشكلة استنزاف المنافذ (port exhaustion) في الخدمات.
-- تطبيق حل لخلل re-rentrancy الناتج من TileNotification في حدث Loaded الخاص بزر الأداة. (نسخة WinUI من خلال متجر مايكروسوفت فقط)
+- تطبيق حل لخلل re-rentrancy الناتج من TileNotification في حدث ~~Loaded~~ *settings updated* الخاص بزر الأداة. (نسخة WinUI من خلال متجر مايكروسوفت فقط)
 
 ### نسخة v4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+### v4.2.2
+
+- Implemented a fix for the re-rentrancy bug caused by TileNotification in the widget's button Loaded event. (WinUI through Microsoft Store only)
+
 ### v4.2.1
 
 - Avoid the port exhaustion problem in service clients.
-- Implemented a fix for the re-rentrancy bug caused by TileNotification in the widget's button Loaded event. (WinUI through Microsoft Store only)
+- Implemented a fix for the re-rentrancy bug caused by TileNotification in the widget's button ~~Loaded~~ *settings updated* event. (WinUI through Microsoft Store only)
 
 ### v4.2
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "assemblyVersion": "4.0",
   "versionHeightOffset": -1,
   "pathFilters": [ "/AwqatSalaat", "/AwqatSalaat.Common", "/AwqatSalaat.WinUI" ],


### PR DESCRIPTION
## Bug fixes

- WinUI (Packaged): Implemented a fix for the re-rentrancy bug caused by TileNotification in the widget's button Loaded event.

> [!note]
> This was supposed to be done in v4.2.1, but by mistake, the fix was done in the settings updated event instead. Oops!